### PR TITLE
Update package URLs

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -170,7 +170,7 @@
         },
         {
             "name": "r2",
-            "url": "https://github.com/radare/v-r2.git",
+            "url": "https://github.com/radare/v-r2",
             "method": "git",
             "vpm": "radare.r2"
         },
@@ -314,7 +314,7 @@
         },
         {
             "name": "vsl",
-            "url": "https://github.com/ulises-jeremias/vsl",
+            "url": "https://github.com/vlang/vsl",
             "method": "git",
             "vpm": "ulises-jeremias.vsl"
         },


### PR DESCRIPTION
Fix `url-check` warnings.

Also, `v-filecheck` and `v-valid` are actually one package, as both URLs leads to https://github.com/gaurav-gogia/v-valid.

Should we remove `v-filecheck` and keep `v-valid`?